### PR TITLE
Vot 88 fulfill checkbox

### DIFF
--- a/client/pages/KitShowAdmin/KitShowAdminPage.js
+++ b/client/pages/KitShowAdmin/KitShowAdminPage.js
@@ -41,6 +41,7 @@ export class KitPage extends React.Component {
           {kit.shippingAddress ? this.renderAddress(kit.shippingAddress) : 'No address provided.'}
           <div>Code: {this.renderCode()}</div>
           <div>{this.renderShipped()} </div>
+          <div>{this.renderFulfill()} </div>
         </div>
       </div>
     );
@@ -55,11 +56,29 @@ export class KitPage extends React.Component {
     );
   }
 
+  renderFulfill() {
+    return (
+      <label>
+        <input type="checkbox" name="noFulfill" checked={!this.state.kit.fulfill} onChange={this.toggleFulfill.bind(this)} />
+        Do Not Fulfill
+      </label>
+    );
+  }
+
   async toggleShipped() {
     const {match} = this.props;
     const isShipped = !this.state.kit.shipped;
     await this.props.patchKit(match.params.kitId, {
       isShipped
+    });
+  }
+
+  async toggleFulfill() {
+    console.log(this.state.kit.fulfill)
+    const {match} = this.props;
+    const fulfill = !this.state.kit.fulfill;
+    await this.props.patchKit(match.params.kitId, {
+      fulfill
     });
   }
 

--- a/client/pages/KitShowAdmin/KitShowAdminPage.js
+++ b/client/pages/KitShowAdmin/KitShowAdminPage.js
@@ -40,28 +40,24 @@ export class KitPage extends React.Component {
           <div>{kit.user.name}</div>
           {kit.shippingAddress ? this.renderAddress(kit.shippingAddress) : 'No address provided.'}
           <div>Code: {this.renderCode()}</div>
-          <div>{this.renderShipped()} </div>
-          <div>{this.renderFulfill()} </div>
+          <div>{this.renderOrderInfo()}</div>
         </div>
       </div>
     );
   }
 
-  renderShipped() {
+  renderOrderInfo() {
     return (
-      <label>
-        <input type="checkbox" name="shipped" checked={this.state.kit.shipped} onChange={this.toggleShipped.bind(this)} />
-        Shipped
-      </label>
-    );
-  }
-
-  renderFulfill() {
-    return (
-      <label>
-        <input type="checkbox" name="noFulfill" checked={!this.state.kit.fulfill} onChange={this.toggleFulfill.bind(this)} />
-        Do Not Fulfill
-      </label>
+      <div>
+        <label>
+          <input data-test-id="orderInfo" type="checkbox" name="shipped" checked={this.state.kit.shipped} onChange={this.toggleShipped.bind(this)} />
+          Shipped
+        </label>
+        <label>
+          <input data-test-id="orderInfo" type="checkbox" name="noFulfill" checked={!this.state.kit.fulfill} onChange={this.toggleFulfill.bind(this)} />
+          Do Not Fulfill
+        </label>
+      </div>
     );
   }
 

--- a/client/pages/KitShowAdmin/KitShowAdminPage.spec.js
+++ b/client/pages/KitShowAdmin/KitShowAdminPage.spec.js
@@ -1,9 +1,0 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import KitShowAdminPage from './KitShowAdminPage';
-
-it('should render KitShowAdminPage', () => {
-  const div = document.createElement('div');
-  ReactDOM.render(
-    <KitShowAdminPage/>, div);
-});

--- a/client/pages/KitShowAdmin/KitShowAdminPage.spec.js
+++ b/client/pages/KitShowAdmin/KitShowAdminPage.spec.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import KitShowAdminPage from './KitShowAdminPage';
+
+it('should render KitShowAdminPage', () => {
+  const div = document.createElement('div');
+  ReactDOM.render(
+    <KitShowAdminPage/>, div);
+});

--- a/sequelize/migrations/20210922055057-kits-fulfill.js
+++ b/sequelize/migrations/20210922055057-kits-fulfill.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+  up: async(queryInterface, DataTypes) => {
+    await queryInterface.addColumn('kits', 'fulfill', {
+      type: DataTypes.BOOLEAN,
+      defaultValue: true,
+      allowNull: false
+    });
+  },
+
+  down: async queryInterface => {
+    await queryInterface.removeColumn('kits', 'fulfill');
+  }
+};

--- a/server/api/kit/index.js
+++ b/server/api/kit/index.js
@@ -11,5 +11,7 @@ router.get('/:kitId', auth.isAuthenticated(), controller.show);
 router.post('/', auth.isAuthenticated(), controller.create);
 router.patch('/:kitId', auth.isAuthenticated(), auth.hasGlobalRole('admin'), controller.patch);
 router.patch('/:kitId/shipped', auth.isAuthenticated(), auth.hasGlobalRole('admin'), controller.patch);
+router.patch('/:kitId/doNotFulfill', auth.isAuthenticated(), auth.hasGlobalRole('admin'), controller.patch);
+
 
 module.exports = router;

--- a/server/api/kit/kit.controller.js
+++ b/server/api/kit/kit.controller.js
@@ -75,7 +75,9 @@ export async function patch(req, res, next) {
 
 function getUpdates(reqBody) {
   let updateValue = {};
-  const {isShipped, code} = reqBody;
+  const {
+    isShipped, code, fulfill
+  } = reqBody;
   if (code !== undefined) {
     updateValue.code = code.length ? code : null;
   }
@@ -86,6 +88,9 @@ function getUpdates(reqBody) {
       const time = new Date().toISOString();
       updateValue.shippedAt = time;
     }
+  }
+  if (fulfill !== undefined) {
+    updateValue.fulfill = fulfill;
   }
   return updateValue;
 }

--- a/server/models/Kit.js
+++ b/server/models/Kit.js
@@ -37,6 +37,11 @@ module.exports = (sequelize, DataTypes) => {
       shippedAt: {
         type: DataTypes.DATE,
         allowNull: true
+      },
+      fulfill: {
+        type: DataTypes.BOOLEAN,
+        defaultValue: true,
+        allowNull: false
       }
     },
     {}


### PR DESCRIPTION
Problem: VotER staff aren't able to indicate to not fulfill a voter kit.

Solution: Added a "do not fulfill" checkbox and 1 field to the Kit db "fulfill".

Result: When the do not fulfill checkbox is marked, it sets the fulfill field to false. When the fulfill checkbox is unchecked, it sets the fulfill field to false.

Original Ticket: https://linear.app/voter/issue/VOT-88/create-a-do-not-fulfill-checkbox-for-kit-orders

![Screen Shot 2021-09-28 at 9 26 29 PM](https://user-images.githubusercontent.com/41392379/135193056-89832345-16d6-44f6-9ca0-85bcf24c3af5.png)
<img width="850" alt="Screen Shot 2021-09-28 at 9 26 38 PM" src="https://user-images.githubusercontent.com/41392379/135193058-9422ffdb-86a0-4b46-a17c-d4d3f9a0c6ec.png">
