### PR TITLE
redirect

### DIFF
--- a/client/pages/OrderKit/OrderKitPage.js
+++ b/client/pages/OrderKit/OrderKitPage.js
@@ -35,7 +35,7 @@ export class OrderKitPage extends React.Component {
           addressLine1, addressLine2, zipcode, city, state
         }
       });
-      this.props.goTo('/signup/order/success');
+      window.location.href = 'https://voter.kindful.com/';
     } catch(err) {
       console.error(err);
     }


### PR DESCRIPTION
Redirects after kit ordering to a donation page: https://voter.kindful.com/ 

Not sure if this will be a good long-term solution: there is no indication that you successfully submitted, nor that you can now log in, etc. 