### PR TITLE
Populate EveryAction custom fields on event ingestion

### DIFF
--- a/server/api/event/event.controller.js
+++ b/server/api/event/event.controller.js
@@ -1,4 +1,7 @@
-import {createEventAndAttachKitMetadata} from '../../services/event/event.service.js';
+import {
+  createEventAndAttachKitMetadata,
+  updateEveryActionEventFields,
+} from '../../services/event/event.service.js';
 
 export async function create(req, res) {
   try {
@@ -10,7 +13,7 @@ export async function create(req, res) {
       os, platform, browser, isMobile, isDesktop, isBot, source: userAgent
     } = req.useragent;
 
-    await createEventAndAttachKitMetadata({
+    const ev = await createEventAndAttachKitMetadata({
       code: ref,
       type,
       destination,
@@ -21,6 +24,12 @@ export async function create(req, res) {
       os,
       platform,
     });
+
+    if (ev.user) {
+      const user = await ev.getUser();
+      await updateEveryActionEventFields(user)
+    }
+
     return res.status(204).end();
   } catch(err) {
     console.error(err);

--- a/server/everyAction.js
+++ b/server/everyAction.js
@@ -13,3 +13,38 @@ export const everyAction = axios.create({
     password: config.everyAction.apiKey,
   },
 });
+
+export async function getOrCreateVanId(user) {
+  const org = await user.getOrganization();
+  const res = await everyAction({
+    method: "POST",
+    url: "/people/findOrCreate",
+    data: {
+      firstName: user.firstName,
+      lastName: user.lastName,
+      emails: [{ email: user.email }],
+      employer: org.name,
+      occupation: user.occupation,
+      jobTitle: user.jobTitle,
+    },
+  });
+  return res.data.vanId;
+}
+
+export async function getEveryActionUser(vanId, params) {
+  const res = await everyAction({
+    method: "GET",
+    url: `/people/${vanId}`,
+    params,
+  });
+  return res.data;
+}
+
+export async function updateEveryActionUser(vanId, data) {
+  const res = await everyAction({
+    method: "PATCH",
+    url: `/people/${vanId}`,
+    data,
+  });
+  return res.data;
+}

--- a/server/services/event/event.service.js
+++ b/server/services/event/event.service.js
@@ -1,4 +1,5 @@
 import {Event, Kit} from '../../models';
+import { getOrCreateVanId, getEveryActionUser, updateEveryActionUser } from "../../everyAction";
 
 export async function createEventAndAttachKitMetadata(body) {
   const {code} = body;
@@ -12,7 +13,73 @@ export async function createEventAndAttachKitMetadata(body) {
       body.kit = kit.id;
       body.organization = kit.organization;
       body.user = kit.user;
+      await updateEveryActionFields(kit, body.destination)
     }
   }
   return Event.create(body);
+}
+
+const CUSTOM_FIELD_GROUP_ID = 95;
+const CUSTOM_FIELD_VOTER_REGISTRATIONS_ID = 379;
+const CUSTOM_FIELD_VOTE_BY_MAIL_ID = 380;
+const CUSTOM_FIELD_TOTAL_ID = 484;
+
+const isVoterRegistration = dest => dest.includes("act.vot-er.org/register-to-vote")
+  || dest.includes("voter.turbovote.org")
+  || dest.includes("act.vot-er.org/registrate-para-votar");
+
+const isVoteByMail = dest => dest.includes("absentee.vote.org");
+
+const getCustomFieldValueFromUser = (user, fieldId) => {
+  const customField = user.customFields.find(f => f.customFieldId === fieldId);
+  if (customField.customField.customFieldTypeId === "N") {
+    return customField.assignedValue != null
+      ? Number(customField.assignedValue)
+      : null;
+  }
+  return customField.assignedValue;
+}
+
+async function getCustomFieldValues(vanId) {
+  const person = await getEveryActionUser(vanId, { "$expand": "customFields" });
+  return {
+    voterRegistrations: getCustomFieldValueFromUser(
+      person,
+      CUSTOM_FIELD_VOTER_REGISTRATIONS_ID
+    ),
+    voteByMail: getCustomFieldValueFromUser(
+      person,
+      CUSTOM_FIELD_VOTE_BY_MAIL_ID
+    ),
+    total: getCustomFieldValueFromUser(
+      person,
+      CUSTOM_FIELD_TOTAL_ID
+    ),
+  };
+}
+
+async function updateEveryActionFields(kit, dest) {
+  const user = await kit.getUser();
+  const vanId = await getOrCreateVanId(user);
+  const { voterRegistrations, voteByMail, total } = getCustomFieldValues(vanId);
+
+  await updateEveryActionUser(vanId, {
+    customFieldValues: [
+      {
+        customFieldId: CUSTOM_FIELD_TOTAL_ID,
+        customFieldGroupId: CUSTOM_FIELD_GROUP_ID,
+        assignedValue: total + 1,
+      },
+      {
+        customFieldId: CUSTOM_FIELD_VOTER_REGISTRATIONS_ID,
+        customFieldGroupId: CUSTOM_FIELD_GROUP_ID,
+        assignedValue: voterRegistrations + (isVoterRegistration(dest) ? 1 : 0),
+      },
+      {
+        customFieldId: CUSTOM_FIELD_VOTE_BY_MAIL_ID,
+        customFieldGroupId: CUSTOM_FIELD_GROUP_ID,
+        assignedValue: voteByMail + (isVoteByMail(dest) ? 1 : 0),
+      }
+    ],
+  });
 }

--- a/server/services/event/event.service.js
+++ b/server/services/event/event.service.js
@@ -1,5 +1,7 @@
-import {Event, Kit} from '../../models';
-import { getOrCreateVanId, getEveryActionUser, updateEveryActionUser } from "../../everyAction";
+import { getOrCreateVanId, updateEveryActionUser } from "../../everyAction";
+import { Event, Kit, Sequelize } from '../../models';
+
+const { Op } = Sequelize;
 
 export async function createEventAndAttachKitMetadata(body) {
   const {code} = body;
@@ -13,7 +15,6 @@ export async function createEventAndAttachKitMetadata(body) {
       body.kit = kit.id;
       body.organization = kit.organization;
       body.user = kit.user;
-      await updateEveryActionFields(kit, body.destination)
     }
   }
   return Event.create(body);
@@ -24,11 +25,73 @@ const CUSTOM_FIELD_VOTER_REGISTRATIONS_ID = 379;
 const CUSTOM_FIELD_VOTE_BY_MAIL_ID = 380;
 const CUSTOM_FIELD_TOTAL_ID = 484;
 
-const isVoterRegistration = dest => dest.includes("act.vot-er.org/register-to-vote")
-  || dest.includes("voter.turbovote.org")
-  || dest.includes("act.vot-er.org/registrate-para-votar");
+const VOTE_BY_MAIL_PATTERN = "absentee.vote.org";
+const VOTER_REGISTRATION_PATTERNS = [
+  "act.vot-er.org/register-to-vote",
+  "voter.turbovote.org",
+  "act.vot-er.org/registrate-para-votar",
+];
 
-const isVoteByMail = dest => dest.includes("absentee.vote.org");
+const patternForLike = pattern => `%${pattern}%`;
+
+async function getCustomFieldValuesFromDb(user) {
+  const voterRegistrations = await Event.count({
+    where: {
+      user: user.id,
+      destination: {
+        [Op.like]: { [Op.any]: VOTER_REGISTRATION_PATTERNS.map(patternForLike) },
+      },
+    },
+  });
+
+  const voteByMail = await Event.count({
+    where: {
+      user: user.id,
+      destination: {
+        [Op.like]: patternForLike(VOTE_BY_MAIL_PATTERN),
+      },
+    },
+  });
+
+  return {
+    voterRegistrations,
+    voteByMail,
+    total: voterRegistrations + voteByMail,
+  };
+}
+
+export async function updateEveryActionEventFields(user) {
+  const vanId = await getOrCreateVanId(user);
+  const { voterRegistrations, voteByMail, total } = await getCustomFieldValuesFromDb(user);
+
+  await updateEveryActionUser(vanId, {
+    customFieldValues: [
+      {
+        customFieldId: CUSTOM_FIELD_VOTER_REGISTRATIONS_ID,
+        customFieldGroupId: CUSTOM_FIELD_GROUP_ID,
+        assignedValue: voterRegistrations
+      },
+      {
+        customFieldId: CUSTOM_FIELD_VOTE_BY_MAIL_ID,
+        customFieldGroupId: CUSTOM_FIELD_GROUP_ID,
+        assignedValue: voteByMail,
+      },
+      {
+        customFieldId: CUSTOM_FIELD_TOTAL_ID,
+        customFieldGroupId: CUSTOM_FIELD_GROUP_ID,
+        assignedValue: total,
+      },
+    ],
+  });
+}
+
+/* Currently unused but might be useful.
+
+const isVoterRegistration = dest => VOTER_REGISTRATION_PATTERNS.any(
+  pattern => dest.includes(pattern)
+);
+
+const isVoteByMail = dest => dest.includes(VOTE_BY_MAIL_PATTERN);
 
 const getCustomFieldValueFromUser = (user, fieldId) => {
   const customField = user.customFields.find(f => f.customFieldId === fieldId);
@@ -40,7 +103,7 @@ const getCustomFieldValueFromUser = (user, fieldId) => {
   return customField.assignedValue;
 }
 
-async function getCustomFieldValues(vanId) {
+async function getCustomFieldValuesFromEa(vanId) {
   const person = await getEveryActionUser(vanId, { "$expand": "customFields" });
   return {
     voterRegistrations: getCustomFieldValueFromUser(
@@ -57,29 +120,4 @@ async function getCustomFieldValues(vanId) {
     ),
   };
 }
-
-async function updateEveryActionFields(kit, dest) {
-  const user = await kit.getUser();
-  const vanId = await getOrCreateVanId(user);
-  const { voterRegistrations, voteByMail, total } = getCustomFieldValues(vanId);
-
-  await updateEveryActionUser(vanId, {
-    customFieldValues: [
-      {
-        customFieldId: CUSTOM_FIELD_TOTAL_ID,
-        customFieldGroupId: CUSTOM_FIELD_GROUP_ID,
-        assignedValue: total + 1,
-      },
-      {
-        customFieldId: CUSTOM_FIELD_VOTER_REGISTRATIONS_ID,
-        customFieldGroupId: CUSTOM_FIELD_GROUP_ID,
-        assignedValue: voterRegistrations + (isVoterRegistration(dest) ? 1 : 0),
-      },
-      {
-        customFieldId: CUSTOM_FIELD_VOTE_BY_MAIL_ID,
-        customFieldGroupId: CUSTOM_FIELD_GROUP_ID,
-        assignedValue: voteByMail + (isVoteByMail(dest) ? 1 : 0),
-      }
-    ],
-  });
-}
+*/


### PR DESCRIPTION
Upon event ingestion, queries for the total amount of matching "voter registration" and "vote by mail" events from the DB by pattern matching the event destination, then updates those values in EveryAction.

We couldn't figure out a way to write useful unit tests for this code but we were able to validate by populating the local DB with some data from the analytics tool and running the commands independently. We also validated that the request body works against the EA API with manual requests.